### PR TITLE
[Feature]Add observedGeneration to represent Workload has reconciled

### DIFF
--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -145,6 +145,10 @@ type WorkloadStatus struct {
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	Phase ZooKeeperOrchestrationPhase `json:"phase,omitempty"`
+
+	// The generation observed by the appConfig controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration"`
 }
 
 // MembersStatus is the status of the members of the cluster with both

--- a/config/crd/bases/cache.ghostbaby.io_workloads.yaml
+++ b/config/crd/bases/cache.ghostbaby.io_workloads.yaml
@@ -1089,6 +1089,10 @@ spec:
               type: string
             leaderNode:
               type: string
+            observedGeneration:
+              description: The generation observed by the appConfig controller.
+              format: int64
+              type: integer
             phase:
               type: string
           type: object

--- a/controllers/workload/provision/observer.go
+++ b/controllers/workload/provision/observer.go
@@ -102,11 +102,16 @@ func (p *Provision) Observer() error {
 	if state.ClusterStats != nil {
 		p.Workload.Status.LeaderNode = state.ClusterStats.LeaderNode
 		p.Workload.Status.AvailableNodes = state.ClusterStats.AvailableNodes
-		p.Workload.Status.LastTransitionTime = metav1.Now()
 	}
+
+	p.Workload.Status.LastTransitionTime = metav1.Now()
 
 	p.ObservedState = &state
 	p.ZKClient = cli
+
+	if p.Workload.Status.ObservedGeneration != p.Workload.Generation {
+		p.Workload.Status.ObservedGeneration = p.Workload.Generation
+	}
 
 	return p.writeStatus()
 }

--- a/controllers/workload/provision/provision.go
+++ b/controllers/workload/provision/provision.go
@@ -53,9 +53,9 @@ func (p *Provision) Reconcile() error {
 			return err
 		}
 
-		//if err := p.ProvisionMonitor(); err != nil {
-		//	return err
-		//}
+		if err := p.ProvisionMonitor(); err != nil {
+			return err
+		}
 
 		if err := p.Observer(); err != nil {
 			return err


### PR DESCRIPTION
Add observedGeneration to represent Workload has reconciled

Fixes #34 #31

Signed-off-by: zhuhuijun <zhuhuijunzhj@gmail.com>